### PR TITLE
Install operator and CC-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,12 @@
 
 The goal of this project is to run Knative using confidential containes instead than plain Docker containers.
 
+## Quick Start
 
+First, get the local `k8s` cluster ready with [`microk8s`](./docs/uk8s.md).
+
+Second, build and install both the operator and the CC runtime. For the operator, we currently pin to version `v0.7.0` and we maintain a separate directory with the source code. TODO: don't rely on a local checkout.
+
+```bash
+inv operator.install
+```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
 # CoCo Serverless
 
-The goal of this project is to run Knative using confidential containes instead than plain Docker containers.
+The goal of this project is to deploy Knative on CoCo and run some baseline benchmarks.
 
 ## Quick Start
 
 First, get the local `k8s` cluster ready with [`microk8s`](./docs/uk8s.md).
 
-Second, build and install both the operator and the CC runtime. For the operator, we currently pin to version `v0.7.0` and we maintain a separate directory with the source code. TODO: don't rely on a local checkout.
+```bash
+inv uk8s.install
+```
+
+Second, build and install both the operator and the CC runtime. For the operator, we currently pin to version `v0.7.0`.
 
 ```bash
 inv operator.install
+inv operator.install-cc-runtime
+```
+
+## Uninstall
+
+In order to uninstall components for debugging purposes, you may un-install the CoCo runtime, and then the operator as follows:
+
+```bash
+inv operator.uninstall-cc-runtime
+inv operator.uninstall
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ First, get the local `k8s` cluster ready with [`microk8s`](./docs/uk8s.md).
 inv uk8s.install
 ```
 
-Second, build and install both the operator and the CC runtime. For the operator, we currently pin to version `v0.7.0`.
+Second, install both the operator and the CC runtime from the upstream tag.
+We currently pin to version `v0.7.0` (see the [`COCO_RELEASE_VERSION` variable](https://github.com/csegarragonz/coco-serverless/tree/main/tasks/util/env.py)).
 
 ```bash
 inv operator.install

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 The goal of this project is to deploy Knative on CoCo and run some baseline benchmarks.
 
+All instructions in this repository assume that you have checked-out the source code, and have activated the python virtual environment:
+
+```bash
+source ./bin/workon.sh
+
+# List available tasks
+inv -l
+```
+
 ## Quick Start
 
 First, get the local `k8s` cluster ready with [`microk8s`](./docs/uk8s.md).

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -2,10 +2,12 @@ from invoke import Collection
 
 from . import format_code
 from . import kubeadm
+from . import operator
 from . import uk8s
 
 ns = Collection(
     format_code,
     kubeadm,
+    operator,
     uk8s,
 )

--- a/tasks/operator.py
+++ b/tasks/operator.py
@@ -1,16 +1,14 @@
 from invoke import task
 from os.path import join
-from subprocess import run
-from tasks.util.env import PROJ_ROOT
-from tasks.util.uk8s import run_uk8s_kubectl_cmd, wait_for_pod, wait_for_pods_in_ns
+from tasks.util.env import COCO_RELEASE_VERSION
+from tasks.util.uk8s import (
+    run_uk8s_kubectl_cmd,
+    wait_for_pod,
+)
+from time import sleep
 
+OPERATOR_GITHUB_URL = "github.com/confidential-containers/operator"
 OPERATOR_NAMESPACE = "confidential-containers-system"
-OPERATOR_SOURCE_CHECKOUT = join(PROJ_ROOT, "..", "operator")
-
-
-@task
-def build(ctx):
-    pass
 
 
 @task
@@ -18,21 +16,84 @@ def install(ctx):
     """
     Install the cc-operator on the cluster
     """
-    config_dir = join(OPERATOR_SOURCE_CHECKOUT, "config", "default")
-    run_uk8s_kubectl_cmd("apply -k {}".format(config_dir))
+    # Before anything, make sure our k8s node has the worker label
+    node_label = "node.kubernetes.io/worker="
+    kube_cmd = """get nodes -o jsonpath='{.items..status..addresses
+                  [?(@.type==\"Hostname\")].address}'"""
+    node_name = run_uk8s_kubectl_cmd(kube_cmd, capture_output=True)
+    run_uk8s_kubectl_cmd("label node {} {}".format(node_name, node_label))
+
+    # Install the operator from the confidential-containers/operator
+    # release tag
+    operator_url = join(
+        OPERATOR_GITHUB_URL, "config", "release?ref=v{}".format(COCO_RELEASE_VERSION)
+    )
+    run_uk8s_kubectl_cmd("apply -k {}".format(operator_url))
     wait_for_pod(OPERATOR_NAMESPACE, "cc-operator-controller-manager")
 
 
 @task
 def install_cc_runtime(ctx, runtime_class="kata-qemu"):
-    cc_runtime_dir = join(OPERATOR_SOURCE_CHECKOUT, "config", "samples", "ccruntime", "default")
-    run_uk8s_kubectl_cmd("create -k {}".format(cc_runtime_dir))
+    """
+    Install the CoCo runtime through the operator
+    """
+    cc_runtime_url = join(
+        OPERATOR_GITHUB_URL,
+        "config",
+        "samples",
+        "ccruntime",
+        "default?ref=v{}".format(COCO_RELEASE_VERSION),
+    )
+    run_uk8s_kubectl_cmd("create -k {}".format(cc_runtime_url))
 
     for pod in ["cc-operator-daemon-install", "cc-operator-pre-install-daemon"]:
         wait_for_pod(OPERATOR_NAMESPACE, pod)
 
+    # We check that the registered runtime classes are the same ones
+    # we expect. We deliberately hardcode the following list
+    expected_runtime_classes = [
+        "kata",
+        "kata-clh",
+        "kata-clh-tdx",
+        "kata-quemu",
+        "kata-qemu-tdx",
+        "kata-qemu-sev",
+        "kata-qemu-snp",
+    ]
+    run_class_cmd = "get runtimeclass -o jsonpath='{.items..handler}'"
+    runtime_classes = run_uk8s_kubectl_cmd(run_class_cmd, capture_output=True).split(
+        " "
+    )
+    while len(expected_runtime_classes) != len(runtime_classes):
+        print(
+            "Not all expected runtime classes are registered ({} != {})".format(
+                len(expected_runtime_classes), len(runtime_classes)
+            )
+        )
+        sleep(5)
+        runtime_classes = run_uk8s_kubectl_cmd(
+            run_class_cmd, capture_output=True
+        ).split(" ")
+
+
+@task
+def uninstall(ctx):
+    """
+    Uninstall the operator
+    """
+    operator_url = join(
+        OPERATOR_GITHUB_URL, "config", "release?ref=v{}".format(COCO_RELEASE_VERSION)
+    )
+    run_uk8s_kubectl_cmd("delete -k {}".format(operator_url))
+
 
 @task
 def uninstall_cc_runtime(ctx):
-    cc_runtime_dir = join(OPERATOR_SOURCE_CHECKOUT, "config", "samples", "ccruntime", "default")
-    run_uk8s_kubectl_cmd("delete -k {}".format(cc_runtime_dir))
+    cc_runtime_url = join(
+        OPERATOR_GITHUB_URL,
+        "config",
+        "samples",
+        "ccruntime",
+        "default?ref=v{}".format(COCO_RELEASE_VERSION),
+    )
+    run_uk8s_kubectl_cmd("delete -k {}".format(cc_runtime_url))

--- a/tasks/operator.py
+++ b/tasks/operator.py
@@ -1,0 +1,38 @@
+from invoke import task
+from os.path import join
+from subprocess import run
+from tasks.util.env import PROJ_ROOT
+from tasks.util.uk8s import run_uk8s_kubectl_cmd, wait_for_pod, wait_for_pods_in_ns
+
+OPERATOR_NAMESPACE = "confidential-containers-system"
+OPERATOR_SOURCE_CHECKOUT = join(PROJ_ROOT, "..", "operator")
+
+
+@task
+def build(ctx):
+    pass
+
+
+@task
+def install(ctx):
+    """
+    Install the cc-operator on the cluster
+    """
+    config_dir = join(OPERATOR_SOURCE_CHECKOUT, "config", "default")
+    run_uk8s_kubectl_cmd("apply -k {}".format(config_dir))
+    wait_for_pod(OPERATOR_NAMESPACE, "cc-operator-controller-manager")
+
+
+@task
+def install_cc_runtime(ctx, runtime_class="kata-qemu"):
+    cc_runtime_dir = join(OPERATOR_SOURCE_CHECKOUT, "config", "samples", "ccruntime", "default")
+    run_uk8s_kubectl_cmd("create -k {}".format(cc_runtime_dir))
+
+    for pod in ["cc-operator-daemon-install", "cc-operator-pre-install-daemon"]:
+        wait_for_pod(OPERATOR_NAMESPACE, pod)
+
+
+@task
+def uninstall_cc_runtime(ctx):
+    cc_runtime_dir = join(OPERATOR_SOURCE_CHECKOUT, "config", "samples", "ccruntime", "default")
+    run_uk8s_kubectl_cmd("delete -k {}".format(cc_runtime_dir))

--- a/tasks/uk8s.py
+++ b/tasks/uk8s.py
@@ -97,6 +97,7 @@ def credentials(ctx):
     run(config_cmd, shell=True, check=True)
 
     # Check we can access the cluster
+    # TODO: actually wait for nodes to be ready
     cmd = "{} get nodes".format(get_uk8s_kubectl_cmd())
     print(cmd)
     run(cmd, shell=True, check=True)

--- a/tasks/uk8s.py
+++ b/tasks/uk8s.py
@@ -3,11 +3,8 @@ from tasks.util.env import (
     K8S_VERSION,
     UK8S_KUBECONFIG_FILE,
 )
+from tasks.util.uk8s import get_uk8s_kubectl_cmd
 from subprocess import run
-
-
-def get_uk8s_kubectl_cmd():
-    return "microk8s kubectl --kubeconfig={}".format(UK8S_KUBECONFIG_FILE)
 
 
 @task

--- a/tasks/util/env.py
+++ b/tasks/util/env.py
@@ -22,3 +22,6 @@ FLANNEL_INSTALL_DIR = join(GLOBAL_INSTALL_DIR, "flannel")
 # MicroK8s config
 
 UK8S_KUBECONFIG_FILE = join(K8S_CONFIG_DIR, "uk8s_kubeconfig")
+
+# CoCo config
+COCO_RELEASE_VERSION = "0.7.0"

--- a/tasks/util/uk8s.py
+++ b/tasks/util/uk8s.py
@@ -6,12 +6,20 @@ UK8S_LOCAL_REGISTRY_PREFIX = "localhost:32000"
 
 
 def get_uk8s_kubectl_cmd():
-    return "microk8s kubectl --kubeconfig={}".format(UK8S_KUBECONFIG_FILE)
+    return "kubectl --kubeconfig={}".format(UK8S_KUBECONFIG_FILE)
 
 
 def run_uk8s_kubectl_cmd(cmd, capture_output=False):
     if capture_output:
-        return run("{} {}".format(get_uk8s_kubectl_cmd(), cmd), shell=True, capture_output=True).stdout.decode("utf-8").strip()
+        return (
+            run(
+                "{} {}".format(get_uk8s_kubectl_cmd(), cmd),
+                shell=True,
+                capture_output=True,
+            )
+            .stdout.decode("utf-8")
+            .strip()
+        )
 
     run("{} {}".format(get_uk8s_kubectl_cmd(), cmd), shell=True, check=True)
 
@@ -45,21 +53,18 @@ def wait_for_pod(ns, pod_name):
         cmd = [
             "-n {}".format(ns) if ns else "",
             "get pods",
-            # "-o jsonpath='{..status.conditions[?(@.type==\"Ready\")].status}'",
+            "-o jsonpath='{..status.conditions[?(@.type==\"Ready\")].status}'",
         ]
 
         output = run_uk8s_kubectl_cmd(
             " ".join(cmd),
             capture_output=True,
         )
-        print(output)
-        sleep(5)
 
-"""
         statuses = [o.strip() for o in output.split(" ") if o.strip()]
         if all([s == "True" for s in statuses]):
             print("All pods ready, continuing...")
             break
 
         print("Pods not ready, waiting ({})".format(output))
-"""
+        sleep(5)

--- a/tasks/util/uk8s.py
+++ b/tasks/util/uk8s.py
@@ -1,0 +1,65 @@
+from subprocess import run
+from tasks.util.env import UK8S_KUBECONFIG_FILE
+from time import sleep
+
+UK8S_LOCAL_REGISTRY_PREFIX = "localhost:32000"
+
+
+def get_uk8s_kubectl_cmd():
+    return "microk8s kubectl --kubeconfig={}".format(UK8S_KUBECONFIG_FILE)
+
+
+def run_uk8s_kubectl_cmd(cmd, capture_output=False):
+    if capture_output:
+        return run("{} {}".format(get_uk8s_kubectl_cmd(), cmd), shell=True, capture_output=True).stdout.decode("utf-8").strip()
+
+    run("{} {}".format(get_uk8s_kubectl_cmd(), cmd), shell=True, check=True)
+
+
+def wait_for_pods_in_ns(ns=None):
+    while True:
+        print("Waiting for pods to be ready...")
+        cmd = [
+            "-n {}".format(ns) if ns else "",
+            "get pods",
+            "-o jsonpath='{..status.conditions[?(@.type==\"Ready\")].status}'",
+        ]
+
+        output = run_uk8s_kubectl_cmd(
+            " ".join(cmd),
+            capture_output=True,
+        )
+
+        statuses = [o.strip() for o in output.split(" ") if o.strip()]
+        if all([s == "True" for s in statuses]):
+            print("All pods ready, continuing...")
+            break
+
+        print("Pods not ready, waiting ({})".format(output))
+        sleep(5)
+
+
+def wait_for_pod(ns, pod_name):
+    while True:
+        print("Waiting for pod {} (ns: {})...".format(pod_name, ns))
+        cmd = [
+            "-n {}".format(ns) if ns else "",
+            "get pods",
+            # "-o jsonpath='{..status.conditions[?(@.type==\"Ready\")].status}'",
+        ]
+
+        output = run_uk8s_kubectl_cmd(
+            " ".join(cmd),
+            capture_output=True,
+        )
+        print(output)
+        sleep(5)
+
+"""
+        statuses = [o.strip() for o in output.split(" ") if o.strip()]
+        if all([s == "True" for s in statuses]):
+            print("All pods ready, continuing...")
+            break
+
+        print("Pods not ready, waiting ({})".format(output))
+"""


### PR DESCRIPTION
In this PR I add scripts to install the CoCo operator and the CoCo runtime (using the operator) from the upstream release tag.

The [following instructions] where very helpful.

For reference, `kustomize` uses `git` features __not__ present in `microk8s` tracked `git` version, which means that we need to use our installation of `kubectl` rather than the one that ships with `microk8s` (which is probably a good thing anyway).