### PR TITLE
Add task to calculate launch digest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansible>=8.4.0
 black>=23.9.1
 invoke>=2.1.0
 python-language-server[all]
+sev-snp-measure>=0.0.7

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -11,6 +11,7 @@ from . import kbs
 from . import knative
 from . import kubeadm
 from . import operator
+from . import sev
 
 ns = Collection(
     apps,
@@ -24,4 +25,5 @@ ns = Collection(
     knative,
     kubeadm,
     operator,
+    sev,
 )

--- a/tasks/sev.py
+++ b/tasks/sev.py
@@ -1,0 +1,58 @@
+from invoke import task
+from json import loads as json_loads
+from os.path import join
+from sevsnpmeasure import guest
+from sevsnpmeasure.sev_mode import SevMode
+from sevsnpmeasure.vmm_types import VMMType
+from sevsnpmeasure.vcpu_types import cpu_sig as sev_snp_cpu_sig
+from subprocess import run
+from tasks.util.env import KATA_CONFIG_DIR
+from tasks.util.toml import read_value_from_toml
+
+
+@task
+def get_launch_digest(ctx, mode="sev"):
+    """
+    Calculate the SEV launch digest from the CoCo configuration file
+
+    To calculate the launch digest we use the sev-snp-measure tool:
+    https://github.com/virtee/sev-snp-measure
+    """
+    # Get CPU information
+    cpu_json_str = (
+        run("lscpu --json", shell=True, check=True, capture_output=True)
+        .stdout.decode("utf-8")
+        .strip()
+    )
+    cpu_json = json_loads(cpu_json_str)
+    cpu_fields = {"CPU family:": None, "Model:": None, "Stepping:": None}
+    for field in cpu_fields:
+        data = next(
+            filter(
+                lambda _dict: _dict["field"] == field,
+                [entry for entry in cpu_json["lscpu"]],
+            ),
+            None,
+        )["data"]
+        cpu_fields[field] = data
+    cpu_sig = sev_snp_cpu_sig(
+        int(cpu_fields["CPU family:"]),
+        int(cpu_fields["Model:"]),
+        int(cpu_fields["Stepping:"]),
+    )
+
+    # Pick the right configuration file
+    toml_path = join(KATA_CONFIG_DIR, "configuration-qemu-{}.toml".format(mode))
+
+    # Finally, calculate the launch digest
+    ld = guest.calc_launch_digest(
+        mode=SevMode.SEV,
+        vcpus=read_value_from_toml(toml_path, "hypervisor.qemu.default_vcpus"),
+        vcpu_sig=cpu_sig,
+        ovmf_file=read_value_from_toml(toml_path, "hypervisor.qemu.firmware"),
+        kernel=read_value_from_toml(toml_path, "hypervisor.qemu.kernel"),
+        initrd=read_value_from_toml(toml_path, "hypervisor.qemu.initrd"),
+        append=read_value_from_toml(toml_path, "hypervisor.qemu.kernel_params"),
+        vmm_type=VMMType.QEMU,
+    )
+    print("Calculated measurement:", ld.hex())


### PR DESCRIPTION
In this PR I add a task to calculate the launch digest from the config files stored in `/opt/confidential-containers` and the CPU information available with `lscpu`.